### PR TITLE
Remove customized RSSI values for M138 device

### DIFF
--- a/EVAL-KIT/FeatherS2/root/code.py
+++ b/EVAL-KIT/FeatherS2/root/code.py
@@ -289,12 +289,6 @@ def tileParseLine(line):
               global DEVTAG, RSSI_RED, RSSI_GREEN
               DEVTAG = v
               # Here is where M138 vs Tile params can be set
-              if DEVTAG == "TILE":
-                RSSI_RED = -91
-                RSSI_GREEN = -95
-              elif DEVTAG == "M138":
-                RSSI_RED = -87
-                RSSI_GREEN = -91
   if parse[0] == '$RT':
     if 'RSSI' in parse[1]:
       if ',' in parse[1]:

--- a/EVAL-KIT/FeatherS2/root/code.py
+++ b/EVAL-KIT/FeatherS2/root/code.py
@@ -1,7 +1,7 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Copyright (C) 2021, Swarm Technologies, Inc.  All rights reserved.  #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-VERSION = '1.3.1'
+VERSION = '1.4'
 import board
 import displayio
 import digitalio


### PR DESCRIPTION
Default values for these are defined with other constants at the top of the file. 

Merging this PR will constitute as release v1.4 for the FeatherS2 Swarm Eval Kit Firmware and M138 Eval Kits will be shipped with this firmware.